### PR TITLE
Downgrade to Openl10n CLI 0.2.0

### DIFF
--- a/openl10n-cli/CHANGELOG.md
+++ b/openl10n-cli/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [1.0.0] - 2017-09-04
 ### Changed
 - Downgrade to Openl10n CLI 0.2.0
 - Update Goss 0.3.4

--- a/openl10n-cli/CHANGELOG.md
+++ b/openl10n-cli/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Downgrade to Openl10n CLI 0.2.0
-- Update Goss 0.3.3
+- Update Goss 0.3.4
 - Update PHP 5.6.31
 
 ## [1.0.0] - 2017-06-01

--- a/openl10n-cli/CHANGELOG.md
+++ b/openl10n-cli/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Downgrade to Openl10n CLI 0.2.0
 - Update Goss 0.3.3
+- Update PHP 5.6.31
 
 ## [1.0.0] - 2017-06-01
 ### Added

--- a/openl10n-cli/CHANGELOG.md
+++ b/openl10n-cli/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Changed
+- Downgrade to Openl10n CLI 0.2.0
 - Update Goss 0.3.3
 
 ## [1.0.0] - 2017-06-01

--- a/openl10n-cli/Dockerfile
+++ b/openl10n-cli/Dockerfile
@@ -51,7 +51,7 @@ RUN docker-php-ext-install calendar
 # Openl10n
 # Must be installed by downloading the phar file because of openl10n issue
 # See https://github.com/openl10n/openl10n-cli/issues/46
-ENV OPENL10N_CLI_VERSION="0.2.1"
+ENV OPENL10N_CLI_VERSION="0.2.0"
 RUN curl -L -o /usr/local/bin/openl10n \
     https://github.com/openl10n/openl10n-cli/releases/download/v${OPENL10N_CLI_VERSION}/openl10n.phar && \
     chmod +x /usr/local/bin/openl10n

--- a/openl10n-cli/Dockerfile
+++ b/openl10n-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:5.6.30-alpine
+FROM php:5.6.31-alpine
 
 MAINTAINER Manala <contact@manala.io>
 

--- a/openl10n-cli/Dockerfile
+++ b/openl10n-cli/Dockerfile
@@ -13,7 +13,7 @@ RUN curl -fsSL https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_
     chmod +x /usr/local/bin/dumb-init
 
 # Goss
-ENV GOSS_VERSION="0.3.3"
+ENV GOSS_VERSION="0.3.4"
 RUN curl -fsSL https://goss.rocks/install | GOSS_VER=v${GOSS_VERSION} sh
 
 # Entrypoint


### PR DESCRIPTION
Openl10n 0.2.0 is required for our openl10n server.