### PR TITLE
Manala

### DIFF
--- a/test-ansible/Dockerfile.centos.7
+++ b/test-ansible/Dockerfile.centos.7
@@ -15,7 +15,8 @@ RUN yum clean all && yum -y update && \
       less vim wget curl make git
 
 # Sudo
-RUN sed -i -e '/secure_path/ s[=.*[&:/usr/local/bin[' /etc/sudoers
+RUN sed -i -e '/secure_path/ s[=.*[&:/usr/local/bin[' /etc/sudoers && \
+    echo "manala ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/manala
 
 # Su exec
 ENV SU_EXEC_VERSION="0.2"
@@ -49,17 +50,23 @@ WORKDIR /srv
 # User #
 ########
 
-ARG USER_ID
-ARG GROUP_ID
+ARG USER_ID=1000
+ARG GROUP_ID=1000
 
-ENV USER_DEFAULT="manala" \
-    USER_ID="${USER_ID:-1000}" \
-    USER_SUDO="1" \
-    GROUP_DEFAULT="manala" \
-    GROUP_ID="${GROUP_ID:-1000}"
+ENV USER_ID=${USER_ID} \
+    GROUP_ID=${GROUP_ID}
 
-RUN groupadd -g ${GROUP_ID} ${GROUP_DEFAULT} && \
-    useradd --key UMASK=022 --shell /bin/bash --uid ${USER_ID} --gid ${GROUP_DEFAULT} ${USER_DEFAULT}
+RUN groupadd \
+      --gid ${GROUP_ID} \
+      manala && \
+    useradd \
+      --create-home \
+      --shell /bin/bash \
+      --uid ${USER_ID} \
+      --gid ${GROUP_ID} \
+      --key UMASK=022 \
+      --comment Manala \
+      manala
 
 ##########
 # Custom #

--- a/test-ansible/Dockerfile.debian.jessie
+++ b/test-ansible/Dockerfile.debian.jessie
@@ -15,6 +15,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade && 
 # Tools
       procps less vim wget curl make git
 
+# Sudo
+RUN echo "manala ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/manala
+
 # Su exec
 ENV SU_EXEC_VERSION="0.2"
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install build-essential && \
@@ -47,17 +50,23 @@ WORKDIR /srv
 # User #
 ########
 
-ARG USER_ID
-ARG GROUP_ID
+ARG USER_ID=1000
+ARG GROUP_ID=1000
 
-ENV USER_DEFAULT="manala" \
-    USER_ID="${USER_ID:-1000}" \
-    USER_SUDO="1" \
-    GROUP_DEFAULT="manala" \
-    GROUP_ID="${GROUP_ID:-1000}"
+ENV ENV USER_ID=${USER_ID} \
+    GROUP_ID=${GROUP_ID}
 
-RUN addgroup --gid ${GROUP_ID} ${GROUP_DEFAULT} && \
-    adduser --disabled-password --shell /bin/bash --gecos ${USER_DEFAULT} --uid ${USER_ID} --ingroup ${GROUP_DEFAULT} ${USER_DEFAULT}
+RUN groupadd \
+      --gid ${GROUP_ID} \
+      manala && \
+    useradd \
+      --create-home \
+      --shell /bin/bash \
+      --uid ${USER_ID} \
+      --gid ${GROUP_ID} \
+      --key UMASK=022 \
+      --comment Manala \
+      manala
 
 ##########
 # Custom #

--- a/test-ansible/entrypoint.sh
+++ b/test-ansible/entrypoint.sh
@@ -1,34 +1,12 @@
 #!/bin/sh
 
-# Try to get group by its given id...
-GROUP=$(getent group "$GROUP_ID" | cut -d: -f1)
-
-# ...fallback to default
-if [ ! "$GROUP" ]; then
-  GROUP="$GROUP_DEFAULT"
-  # Update group id
-  sed -i s/$GROUP:x:[0-9]*:/$GROUP:x:$GROUP_ID:/ /etc/group
+if [ ${USER_ID} != $(id -u manala) ]; then
+  usermod --non-unique --uid ${USER_ID} manala
 fi
 
-# Try to get user by its given id...
-USER=$(getent passwd "$USER_ID" | cut -d: -f1)
-
-# ...fallback to default
-if [ ! "$USER" ]; then
-  USER="$USER_DEFAULT"
+if [ ${GROUP_ID} != $(id -g manala) ]; then
+  groupmod --non-unique --gid ${GROUP_ID} manala
+  chgrp -R manala /home/manala
 fi
 
-# Update user id
-sed -i s/$USER:x:[0-9]*:[0-9]*:/$USER:x:$USER_ID:$GROUP_ID:/ /etc/passwd
-
-# Fix user home permissions
-if [ "$USER" = "$USER_DEFAULT" ]; then
-  chown -R $USER:$GROUP /home/$USER
-fi
-
-# Sudo
-if [ "$USER_SUDO" ]; then
-  echo "$USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/manala
-fi
-
-exec su-exec "$USER" "$@"
+exec su-exec manala "${@}"


### PR DESCRIPTION
- [ ]  Manalize
- [ ] Normalize mana user creation
- [ ]  Semver everywhere (yes, even for you, ansible and hugo)
- [ ] Naming
- [ ] Better entrypoint
- [ ] Give docker multistage a try (supported in travis ? in docker hub ?)(See: https://github.com/travis-ci/travis-ci/issues/8181)
```
##################
# Stage - System #
##################

FROM centos:7 as system

RUN yum --assumeyes install curl make gcc

ENV SU_EXEC_VERSION="0.2"
WORKDIR /srv/su-exec
RUN curl --location https://github.com/ncopa/su-exec/archive/v${SU_EXEC_VERSION}.tar.gz \
      | tar zxfv - --strip-components 1 \
    && make

ENV DUMB_INIT_VERSION="1.2.0"
WORKDIR /srv/dumb-init
RUN curl --location https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VERSION}/dumb-init_${DUMB_INIT_VERSION}_amd64 \
      --output dumb-init \
    && chmod +x dumb-init

ENV GOSS_VERSION="0.3.5"
WORKDIR /srv/goss
RUN curl --location https://goss.rocks/install \
      | GOSS_VER=v${GOSS_VERSION} GOSS_DST=. sh

########
# Main #
########

FROM centos:7

MAINTAINER Manala <contact@manala.io>

USER root

RUN yum clean all && yum -y update \
    && yum --assumeyes install \
      sudo \
      bash bash-completion \
      less vim wget curl make git

COPY --from=system [ \
  "/srv/su-exec/su-exec",  \
  "/srv/dumb-init/dumb-init", \
  "/srv/goss/goss", \
  "/usr/local/bin/" \
]

########
# User #
########

# User
RUN groupadd --gid 1000 manala \
    && useradd --shell /bin/bash --uid 1000 --gid 1000 manala

# Sudo
RUN sed --in-place '/secure_path/ s[=.*[&:/usr/local/bin[' /etc/sudoers \
    && echo "manala ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/manala

# Entrypoint
COPY entrypoint.sh /usr/local/bin/
ENTRYPOINT ["entrypoint.sh"]

# Shell
CMD ["/bin/bash"]

# Working directory
WORKDIR /srv

##########
# Custom #
##########

```
