### PR TITLE
Introduce auto release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@
 ## Colors
 COLOR_RESET   = \033[0m
 COLOR_INFO    = \033[32m
-COLOR_COMMENT = \033[33m
+COLOR_WARNING = \033[33m
+COLOR_COMMENT = \033[36m
 
 # Git
 GIT_REPOSITORIES_DELTA = ${shell git diff --name-only ${TRAVIS_COMMIT_RANGE} | grep "/" | cut -d "/" -f1 | sort -u | tr "\n" " "}
@@ -53,12 +54,15 @@ test:
 		printf "\n${COLOR_INFO}Test ${COLOR_COMMENT}${repository}${COLOR_RESET}\n\n" && ${MAKE} --directory=${repository} test || EXIT=$$? ;\
 	} exit $$EXIT
 
-#########
-# Split #
-#########
+###########
+# Release #
+###########
 
-## Split
-split:
+## Release
+release:
+	printf "\n$(COLOR_INFO) ༼ つ ◕_◕ ༽つ $(COLOR_WARNING)You are about to release *ALL* images, please confirm! (y/N)$(COLOR_RESET): "; \
+	read CONFIRM ; if [ "$$CONFIRM" != "y" ]; then printf "\n"; exit 1; fi; \
+	printf "\n"
 ifeq (${shell uname -s},Darwin)
 	docker run \
 		--rm \

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # Docker Images [![Build Status](https://travis-ci.org/manala/docker-images.svg?branch=master)](https://travis-ci.org/manala/docker-images)
+
+## Release
+
+```
+make release
+```
+
+### Set Chandler github api token
+
+```
+export CHANDLER_GITHUB_API_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+travis login
+travis repos -o manala -a --no-interactive | xargs -n1 travis env set CHANDLER_GITHUB_API_TOKEN $CHANDLER_GITHUB_API_TOKEN --private --repo
+```

--- a/build-debian/.travis.yml
+++ b/build-debian/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -12,6 +16,13 @@ env:
 script:
   - make build
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/client-openstack/.travis.yml
+++ b/client-openstack/.travis.yml
@@ -1,11 +1,22 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
 script:
   - make build
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/hugo/.travis.yml
+++ b/hugo/.travis.yml
@@ -1,11 +1,22 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
 script:
   - make build
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/openl10n-cli/.travis.yml
+++ b/openl10n-cli/.travis.yml
@@ -1,11 +1,22 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
 script:
   - make build
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/php-cs-fixer/.travis.yml
+++ b/php-cs-fixer/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -10,6 +14,13 @@ before_install:
 script:
   - make build
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/security-checker/.travis.yml
+++ b/security-checker/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -10,6 +14,13 @@ before_install:
 script:
   - make build
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:

--- a/test-ansible/.travis.yml
+++ b/test-ansible/.travis.yml
@@ -1,5 +1,9 @@
 language: generic
 
+branches:
+  only:
+    - master
+
 services:
   - docker
 
@@ -14,6 +18,13 @@ env:
 script:
   - make build
   - make test
+
+jobs:
+  include:
+    - stage: release
+      script:
+        - gem install chandler -v 0.7.0
+        - chandler push `perl -lne '/^## \[(?!Unreleased)([\w.-]+)\] - [\w-]+$/ && print $1;' CHANGELOG.md | head -1`
 
 notifications:
   webhooks:


### PR DESCRIPTION
I'm tired of manual release....

- [x] Replace `make split` by `make release`. From now, the single repo is the virtual master branch for all sub repos. Once it's git-splitted, if tests has passed, every updated sub repo is tagged from master, using release note from last changelog entry.
- [x] Use [chandler](https://github.com/mattbrictson/chandler/releases) to ensure github/changelog synchronization
- [x] Use travis build stages (beta) to push release if tests passed